### PR TITLE
fix: considering s3 error from s3.upload()

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,11 @@ const paths = klawSync(SOURCE_DIR, {
 });
 
 function upload(params) {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     s3.upload(params, (err, data) => {
-      if (err) core.error(err);
+      if (err) {
+        reject(err);
+      }
       core.info(`uploaded - ${data.Key}`);
       core.info(`located - ${data.Location}`);
       resolve(data.Location);


### PR DESCRIPTION
```
when an error occurs at s3.upload()
current code was trying to execute the happy path.

  core.info(...data);
  resolve(...data);

this fix adds a execution-branch break if error.
```